### PR TITLE
bug fixing at woocommerce-ac.php line 1531

### DIFF
--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -1528,7 +1528,7 @@ function woocommerce_ac_delete(){
 						} else {
 						     $add_var = "";
 						}    
-						$i = 1 + $add_var;
+						$i = 1 + intval($add_var);
 						foreach ( $results as $key => $value )
 						{
 								$id = $value->id;


### PR DESCRIPTION
Hello!! Have a nice day.

I was trying this plugin for one of our clients and I discovered a fatal error. Basically, on woocommerce-ac.php line 1531 it was trying to add a string to an int and it returned a critical error which broke the plugin. I changed that line of code and now the critical error is gone.

Also, I have noticed that I can't send test emails for the templates I create. I don't know if it has anything to do with the fact that I am working locally but the solution to this issue is way beyond my technical abilities so far.